### PR TITLE
improvements to preview pane:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,25 @@ All notable changes to the OpenSCAD IntelliJ Plugin will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2025-12-29
+
+### Added
+- **Debug Preview** - PNG-based preview that shows OpenSCAD debug modifiers (`#`, `%`, `!`, `*`) with proper colors
+- **Orientation Cube** - Interactive 3D orientation cube in upper right corner for quick view switching (Front/Back/Left/Right/Top/Bottom)
+- **Export STL Button** - Direct export from preview pane toolbar with file save dialog
+- **Camera Orientation Sync** - Debug preview renders from the same camera angle as the 3D view
+- **OPENSCADPATH Support** - Run/debug configurations now properly set OPENSCADPATH from library path settings
+- **OS-specific Path Separator** - Library paths use correct separator (`:` on Unix, `;` on Windows)
+
+### Changed
+- **Improved 3D Rendering** - Backface culling for cleaner surface-only display
+- **Camera-relative Shading** - Faces pointing toward viewer are brighter
+- **Model Color** - Changed default color from yellow to light gray (`#c1c1c1`)
+- **Resizable Preview** - Preview pane can now be resized by dragging the splitter
+
+### Fixed
+- Kotlin stdlib conflict warning in Gradle configuration
+- Triangle edge visibility in solid render mode
 
 ## [1.0.1] - 2025-11-30
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,34 @@ Open any `.scad` file to see the split editor with live 3D preview.
 - **Render** - Generate STL preview
 - **Reset View** - Reset camera
 - **Wireframe** - Toggle wireframe/solid view
+- **Debug Preview** - Show OpenSCAD debug modifiers (see below)
+- **Export STL** - Export directly to STL file
 - **Auto-render** - Enable automatic rendering on save
+
+**3D Navigation:**
+- **Left-click + drag** - Rotate model
+- **Right-click + drag** - Pan view
+- **Mouse wheel** - Zoom in/out
+- **Orientation Cube** - Click faces (Front/Back/Left/Right/Top/Bottom) to snap to that view
+
+### Debug Preview
+
+The **Debug Preview** feature renders your model as OpenSCAD sees it, showing debug modifiers with their proper colors:
+
+| Modifier | Name | Effect in Debug Preview |
+|----------|------|------------------------|
+| `#` | Debug | Highlighted in transparent red/pink |
+| `%` | Background | Shown in transparent gray |
+| `!` | Root | Only this object is rendered |
+| `*` | Disable | Object is hidden |
+
+**Usage:**
+1. Add debug modifiers to your code (e.g., `#cube(10);`)
+2. Click **Debug Preview** button in the toolbar
+3. The preview shows a PNG rendered by OpenSCAD with debug colors
+4. Click **3D View** to return to the interactive 3D model
+
+**Note:** Debug preview preserves your current camera orientation, so you can rotate the 3D view first, then click Debug Preview to see the same angle with debug colors
 
 ### Export
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,13 @@ plugins {
     id("org.jetbrains.grammarkit") version "2022.3.2.2"
 }
 
+// Kotlin stdlib is provided by IntelliJ Platform (configured in gradle.properties)
+kotlin {
+    compilerOptions {
+        apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8)
+    }
+}
+
 group = "org.openscad"
 version = "0.1.0"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+# Disable automatic Kotlin stdlib dependency - IntelliJ Platform provides it
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
## [1.1.0] - 2025-12-29

### Added
- **Debug Preview** - PNG-based preview that shows OpenSCAD debug modifiers (`#`, `%`, `!`, `*`) with proper colors
- **Orientation Cube** - Interactive 3D orientation cube in upper right corner for quick view switching (Front/Back/Left/Right/Top/Bottom)
- **Export STL Button** - Direct export from preview pane toolbar with file save dialog
- **Camera Orientation Sync** - Debug preview renders from the same camera angle as the 3D view
- **OPENSCADPATH Support** - Run/debug configurations now properly set OPENSCADPATH from library path settings
- **OS-specific Path Separator** - Library paths use correct separator (`:` on Unix, `;` on Windows)

### Changed
- **Improved 3D Rendering** - Backface culling for cleaner surface-only display
- **Camera-relative Shading** - Faces pointing toward viewer are brighter
- **Model Color** - Changed default color from yellow to light gray (`#c1c1c1`)
- **Resizable Preview** - Preview pane can now be resized by dragging the splitter

### Fixed
- Kotlin stdlib conflict warning in Gradle configuration
- Triangle edge visibility in solid render mode