### PR TITLE
- **Custom Temp Directory Setting** - Configure custom directory for …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the OpenSCAD IntelliJ Plugin will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-01-02
+
+### Added
+- **Custom Temp Directory Setting** - Configure custom directory for render temp files in Settings → Tools → OpenSCAD
+- **Automatic Temp Cleanup** - Old preview temp directories are automatically deleted in background when creating new renders
+
+### Fixed
+- **Windows Compatibility** - OS-independent library paths now properly support Windows:
+  - `%USERPROFILE%\Documents\OpenSCAD\libraries`
+  - `%PROGRAMFILES%\OpenSCAD\libraries`
+  - `%PROGRAMFILES(X86)%\OpenSCAD\libraries`
+- **Windows OpenSCAD Detection** - Uses `where` command instead of `which` on Windows to find OpenSCAD in PATH
+- **Linux Flatpak Compatibility** - Temp directory uses `~/.cache/openscad-plugin/` on Linux instead of `/tmp/` to support sandboxed Flatpak OpenSCAD installations
+
+### Technical
+- Refactored OS-specific library paths into `OpenSCADPathUtils` utility class
+- Added `isWindows()` and `isLinux()` helper functions
+- Centralized temp directory creation with `createTempDirectory()` helper
+
 ## [1.2.0] - 2026-01-01
 
 ### Added

--- a/src/main/kotlin/org/openscad/references/OpenSCADImportResolver.kt
+++ b/src/main/kotlin/org/openscad/references/OpenSCADImportResolver.kt
@@ -105,13 +105,8 @@ object OpenSCADImportResolver {
             // Settings not available, continue with common paths
         }
         
-        // Then add common library locations
-        allPaths.addAll(listOf(
-            "/usr/share/openscad/libraries",
-            "/usr/local/share/openscad/libraries",
-            System.getProperty("user.home") + "/.local/share/OpenSCAD/libraries",
-            System.getProperty("user.home") + "/Documents/OpenSCAD/libraries"
-        ))
+        // Then add common library locations based on OS
+        allPaths.addAll(org.openscad.util.OpenSCADPathUtils.getCommonLibraryPaths())
         
         for (libPath in allPaths) {
             val libDir = LocalFileSystem.getInstance().findFileByPath(libPath)

--- a/src/main/kotlin/org/openscad/references/OpenSCADLibraryIndexer.kt
+++ b/src/main/kotlin/org/openscad/references/OpenSCADLibraryIndexer.kt
@@ -135,15 +135,8 @@ class OpenSCADLibraryIndexer(private val project: Project) {
             }
         }
         
-        // Add common OpenSCAD library locations
-        val commonPaths = listOf(
-            "/usr/share/openscad/libraries",
-            "/usr/local/share/openscad/libraries",
-            System.getProperty("user.home") + "/.local/share/OpenSCAD/libraries",
-            System.getProperty("user.home") + "/Documents/OpenSCAD/libraries"
-        )
-        
-        paths.addAll(commonPaths.filter { File(it).exists() })
+        // Add common OpenSCAD library locations based on OS
+        paths.addAll(org.openscad.util.OpenSCADPathUtils.getExistingLibraryPaths())
         
         return paths.distinct()
     }

--- a/src/main/kotlin/org/openscad/references/OpenSCADLibraryRootsProvider.kt
+++ b/src/main/kotlin/org/openscad/references/OpenSCADLibraryRootsProvider.kt
@@ -61,15 +61,8 @@ class OpenSCADLibraryRootsProvider : AdditionalLibraryRootsProvider() {
             }
         }
         
-        // Add common OpenSCAD library locations
-        val commonPaths = listOf(
-            "/usr/share/openscad/libraries",
-            "/usr/local/share/openscad/libraries",
-            System.getProperty("user.home") + "/.local/share/OpenSCAD/libraries",
-            System.getProperty("user.home") + "/Documents/OpenSCAD/libraries"
-        )
-        
-        paths.addAll(commonPaths.filter { File(it).exists() })
+        // Add common OpenSCAD library locations based on OS
+        paths.addAll(org.openscad.util.OpenSCADPathUtils.getExistingLibraryPaths())
         
         return paths.distinct()
     }

--- a/src/main/kotlin/org/openscad/run/OpenSCADRunConfiguration.kt
+++ b/src/main/kotlin/org/openscad/run/OpenSCADRunConfiguration.kt
@@ -122,15 +122,8 @@ class OpenSCADRunConfiguration(
                     }
                 }
                 
-                // Add common OpenSCAD library locations
-                val commonPaths = listOf(
-                    "/usr/share/openscad/libraries",
-                    "/usr/local/share/openscad/libraries",
-                    System.getProperty("user.home") + "/.local/share/OpenSCAD/libraries",
-                    System.getProperty("user.home") + "/Documents/OpenSCAD/libraries"
-                )
-                
-                paths.addAll(commonPaths.filter { File(it).exists() })
+                // Add common OpenSCAD library locations based on OS
+                paths.addAll(org.openscad.util.OpenSCADPathUtils.getExistingLibraryPaths())
                 
                 // Join with platform-specific path separator (: on Unix, ; on Windows)
                 return paths.joinToString(File.pathSeparator)

--- a/src/main/kotlin/org/openscad/settings/OpenSCADSettings.kt
+++ b/src/main/kotlin/org/openscad/settings/OpenSCADSettings.kt
@@ -31,6 +31,9 @@ class OpenSCADSettings : PersistentStateComponent<OpenSCADSettings> {
     // Library paths
     var libraryPaths: MutableList<String> = mutableListOf()
     
+    // Custom temp directory (empty = use system default, with Linux Flatpak-friendly fallback)
+    var customTempDirectory: String = ""
+    
     override fun getState(): OpenSCADSettings = this
     
     override fun loadState(state: OpenSCADSettings) {

--- a/src/main/kotlin/org/openscad/util/OpenSCADPathUtils.kt
+++ b/src/main/kotlin/org/openscad/util/OpenSCADPathUtils.kt
@@ -1,0 +1,130 @@
+package org.openscad.util
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Utility functions for OS-independent path handling in OpenSCAD plugin
+ */
+object OpenSCADPathUtils {
+    
+    /**
+     * Returns a list of common OpenSCAD library paths appropriate for the current OS.
+     * Paths are not filtered for existence - caller should filter if needed.
+     */
+    fun getCommonLibraryPaths(): List<String> {
+        val userHome = System.getProperty("user.home")
+        return when {
+            System.getProperty("os.name").contains("Windows", ignoreCase = true) -> listOf(
+                "$userHome\\Documents\\OpenSCAD\\libraries",
+                System.getenv("PROGRAMFILES")?.let { "$it\\OpenSCAD\\libraries" },
+                System.getenv("PROGRAMFILES(X86)")?.let { "$it\\OpenSCAD\\libraries" }
+            ).filterNotNull()
+            else -> listOf( // Unix-like (macOS, Linux)
+                "/usr/share/openscad/libraries",
+                "/usr/local/share/openscad/libraries",
+                "$userHome/.local/share/OpenSCAD/libraries",
+                "$userHome/Documents/OpenSCAD/libraries"
+            )
+        }
+    }
+    
+    /**
+     * Returns common OpenSCAD library paths that exist on the current system.
+     */
+    fun getExistingLibraryPaths(): List<String> {
+        return getCommonLibraryPaths().filter { File(it).exists() }
+    }
+    
+    /**
+     * Returns true if the current OS is Windows.
+     */
+    fun isWindows(): Boolean {
+        return System.getProperty("os.name").contains("Windows", ignoreCase = true)
+    }
+    
+    /**
+     * Returns true if the current OS is Linux.
+     */
+    fun isLinux(): Boolean {
+        return System.getProperty("os.name").contains("Linux", ignoreCase = true)
+    }
+    
+    /**
+     * Creates a temporary directory for OpenSCAD output that is accessible by
+     * sandboxed applications like Flatpak.
+     * 
+     * Priority:
+     * 1. Custom directory from settings (if provided and valid)
+     * 2. On Linux: ~/.cache/openscad-plugin/ (Flatpak-compatible)
+     * 3. On other systems: standard system temp directory
+     * 
+     * Before creating a new directory, collects all existing preview directories
+     * and deletes them in a background thread, ensuring only one directory exists.
+     * 
+     * @param prefix Prefix for the temp directory name
+     * @param customTempDir Optional custom temp directory from settings (empty = use default)
+     * @return Path to the created temporary directory
+     */
+    fun createTempDirectory(prefix: String, customTempDir: String = ""): Path {
+        // Determine the parent directory for temp files
+        val parentDir: File = when {
+            customTempDir.isNotBlank() -> {
+                val customDir = File(customTempDir)
+                if (!customDir.exists()) {
+                    customDir.mkdirs()
+                }
+                customDir
+            }
+            isLinux() -> {
+                val cacheDir = File(System.getProperty("user.home"), ".cache/openscad-plugin")
+                if (!cacheDir.exists()) {
+                    cacheDir.mkdirs()
+                }
+                cacheDir
+            }
+            else -> {
+                File(System.getProperty("java.io.tmpdir"))
+            }
+        }
+        
+        // Collect existing preview directories before creating new one
+        val existingDirs = getExistingTempDirectories(parentDir, prefix)
+        
+        // Create the new temp directory first
+        val newDir = Files.createTempDirectory(parentDir.toPath(), prefix)
+        
+        // Delete old directories in background thread
+        if (existingDirs.isNotEmpty()) {
+            Thread {
+                existingDirs.forEach { dir ->
+                    try {
+                        dir.deleteRecursively()
+                    } catch (e: Exception) {
+                        // Ignore errors during cleanup
+                    }
+                }
+            }.start()
+        }
+        
+        return newDir
+    }
+    
+    /**
+     * Gets all existing temporary directories that match the prefix.
+     * 
+     * @param parentDir The parent directory containing temp directories
+     * @param prefix The prefix used for temp directory names
+     * @return List of directories to be deleted
+     */
+    private fun getExistingTempDirectories(parentDir: File, prefix: String): List<File> {
+        if (!parentDir.exists() || !parentDir.isDirectory) {
+            return emptyList()
+        }
+        
+        return parentDir.listFiles()?.filter { file ->
+            file.isDirectory && file.name.startsWith(prefix)
+        } ?: emptyList()
+    }
+}


### PR DESCRIPTION
…render temp files in Settings → Tools → OpenSCAD

- **Automatic Temp Cleanup** - Old preview temp directories are automatically deleted in background when creating new renders

- **Windows Compatibility** - OS-independent library paths now properly support Windows:
  - `%USERPROFILE%\Documents\OpenSCAD\libraries`
  - `%PROGRAMFILES%\OpenSCAD\libraries`
  - `%PROGRAMFILES(X86)%\OpenSCAD\libraries`
- **Windows OpenSCAD Detection** - Uses `where` command instead of `which` on Windows to find OpenSCAD in PATH
- **Linux Flatpak Compatibility** - Temp directory uses `~/.cache/openscad-plugin/` on Linux instead of `/tmp/` to support sandboxed Flatpak OpenSCAD installations

- Refactored OS-specific library paths into `OpenSCADPathUtils` utility class
- Added `isWindows()` and `isLinux()` helper functions
- Centralized temp directory creation with `createTempDirectory()` helper