### PR TITLE
 Fix 3D preview colors, lighting, and rendering artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the OpenSCAD IntelliJ Plugin will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-02-16
+
+### Added
+- **Hardware-Accelerated 3D Viewer** - Optional JOGL/OpenGL viewer for smoother 3D preview (Settings → Tools → OpenSCAD → "Use hardware-accelerated 3D viewer")
+- Falls back gracefully to software renderer if OpenGL initialization fails
+- Preview mode menu adapts to viewer capabilities (Wireframe and Debug modes only available with software renderer)
+
+### Fixed
+- **JOGL Viewer Lighting** - Fixed blown-out lighting in hardware-accelerated viewer caused by non-normalized normals after model scaling (`GL_NORMALIZE`)
+- **JOGL Viewer Rendering** - Enabled back-face culling and corrected material properties to eliminate visual artifacts
+
 ## [1.3.1] - 2026-02-01
 
 ### Added

--- a/src/main/kotlin/org/openscad/editor/OpenSCADPreviewFileEditor.kt
+++ b/src/main/kotlin/org/openscad/editor/OpenSCADPreviewFileEditor.kt
@@ -34,23 +34,23 @@ class OpenSCADPreviewFileEditor(
     private val project: Project,
     private val file: VirtualFile
 ) : UserDataHolderBase(), FileEditor {
-
+    
     private val logger = Logger.getInstance(OpenSCADPreviewFileEditor::class.java)
     private val settings = OpenSCADSettings.getInstance(project)
     private val renderer = OpenSCADRenderer(project)
     private val stlParser = STLParser()
     private val threemfParser = ThreeMFParser()
-
+    
     private val component: JComponent
     private val viewer: Any
     private val viewerPanel: JComponent
-
+    
     private val statusLabel = JLabel("Ready")
     private val renderButton = JButton("Render")
     private val resetViewButton = JButton("Reset View")
     private val previewModeButton = JButton("Preview: 3D ▼")
     private var currentPreviewMode = PreviewMode.SOLID_3D
-
+    
     private enum class PreviewMode(val displayName: String) {
         SOLID_3D("3D"),
         WIREFRAME("Wireframe"),
@@ -58,9 +58,9 @@ class OpenSCADPreviewFileEditor(
     }
     private val exportButton = JButton("Export ▼")
     private val autoRenderCheckbox = JCheckBox("auto-refresh")
-
+    
     private var isRendering = false
-
+    
     init {
         // Initialize viewer based on hardware acceleration setting
         val (panel, viewerInstance) = if (settings.useHardwareAcceleration) {
@@ -94,23 +94,23 @@ class OpenSCADPreviewFileEditor(
             toolbar.add(autoRenderCheckbox)
             toolbar.add(Box.createHorizontalStrut(10))
             toolbar.add(statusLabel)
-
+            
             add(toolbar, BorderLayout.NORTH)
             add(viewerPanel, BorderLayout.CENTER)
         }
-
+        
         // Initialize auto-refresh from settings
         autoRenderCheckbox.isSelected = settings.autoRenderOnSave
-
+        
         setupListeners()
         checkOpenSCADAvailability()
     }
-
+    
     private fun setupListeners() {
         renderButton.addActionListener {
             renderForCurrentMode()
         }
-
+        
         resetViewButton.addActionListener {
             when (viewer) {
                 is STLViewer3D -> viewer.resetView()
@@ -135,7 +135,7 @@ class OpenSCADPreviewFileEditor(
             }
             popup.show(previewModeButton, 0, previewModeButton.height)
         }
-
+        
         exportButton.addActionListener { e ->
             val popup = JPopupMenu()
             popup.add(JMenuItem("Export STL").apply {
@@ -146,14 +146,14 @@ class OpenSCADPreviewFileEditor(
             })
             popup.show(exportButton, 0, exportButton.height)
         }
-
+        
         autoRenderCheckbox.addActionListener {
             settings.autoRenderOnSave = autoRenderCheckbox.isSelected
             if (autoRenderCheckbox.isSelected) {
                 renderForCurrentMode()
             }
         }
-
+        
         // Listen for file save events
         val connection = project.messageBus.connect()
         connection.subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, object : FileEditorManagerListener {
@@ -161,7 +161,7 @@ class OpenSCADPreviewFileEditor(
                 // Cleanup when file is closed
             }
         })
-
+        
         // Listen for file save events using bulk file listener
         connection.subscribe(com.intellij.openapi.vfs.VirtualFileManager.VFS_CHANGES,
             object : BulkFileListener {
@@ -178,7 +178,7 @@ class OpenSCADPreviewFileEditor(
             }
         )
     }
-
+    
     private fun renderForCurrentMode() {
         when (currentPreviewMode) {
             PreviewMode.SOLID_3D -> {
@@ -217,31 +217,31 @@ class OpenSCADPreviewFileEditor(
             updateStatus("✓ Ready to render")
         }
     }
-
+    
     private fun renderFile() {
         if (isRendering) {
             updateStatus("Already rendering...")
             return
         }
-
+        
         if (!file.isValid) {
             updateStatus("✗ File is not valid")
             return
         }
-
+        
         isRendering = true
         renderButton.isEnabled = false
         updateStatus("Rendering ${file.name}...")
-
+        
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 // Try 3MF first (preserves colors from color() statements)
                 logger.info("Starting 3MF render for ${file.name}")
                 val threemfPath = renderer.renderTo3MF(file)
-
+                
                 if (threemfPath != null) {
                     val coloredModel = threemfParser.parse(threemfPath)
-
+                    
                     if (coloredModel != null && coloredModel.triangles.isNotEmpty()) {
                         logger.info("3MF parsed: ${coloredModel.triangles.size} triangles")
                         SwingUtilities.invokeLater {
@@ -254,14 +254,14 @@ class OpenSCADPreviewFileEditor(
                         return@executeOnPooledThread
                     }
                 }
-
+                
                 // Fall back to STL if 3MF fails
                 logger.info("Falling back to STL render")
                 val stlPath = renderer.renderToSTL(file)
-
+                
                 if (stlPath != null) {
                     val model = stlParser.parse(stlPath)
-
+                    
                     SwingUtilities.invokeLater {
                         if (model != null) {
                             when (viewer) {
@@ -291,13 +291,13 @@ class OpenSCADPreviewFileEditor(
             }
         }
     }
-
+    
     private fun updateStatus(message: String) {
         SwingUtilities.invokeLater {
             statusLabel.text = message
         }
     }
-
+    
     private fun setPreviewMode(mode: PreviewMode) {
         currentPreviewMode = mode
         previewModeButton.text = "Preview: ${mode.displayName} ▼"
@@ -309,18 +309,18 @@ class OpenSCADPreviewFileEditor(
             updateStatus("Already rendering...")
             return
         }
-
+        
         if (!file.isValid) {
             updateStatus("✗ File is not valid")
             return
         }
-
+        
         val viewerPanel = viewer as? STLViewerPanel
-
+        
         isRendering = true
         renderButton.isEnabled = false
         updateStatus("Rendering debug preview...")
-
+        
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 // Get current view parameters for camera synchronization
@@ -333,7 +333,7 @@ class OpenSCADPreviewFileEditor(
                     )
                 }
                 val pngPath = renderer.renderToPNG(file, 1024, 768, cameraParams)
-
+                
                 SwingUtilities.invokeLater {
                     if (pngPath != null) {
                         viewerPanel?.setPreviewImage(pngPath)
@@ -355,26 +355,26 @@ class OpenSCADPreviewFileEditor(
             }
         }
     }
-
+    
     private fun exportSTL() {
         if (!file.isValid) {
             updateStatus("✗ File is not valid")
             return
         }
-
+        
         // Show file save dialog
         val descriptor = FileSaverDescriptor("Export to STL", "Choose output STL file", "stl")
         val saveDialog = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
         val fileWrapper = saveDialog.save(file.parent, file.nameWithoutExtension + ".stl") ?: return
-
+        
         val outputFile = fileWrapper.file
-
+        
         updateStatus("Exporting to ${outputFile.name}...")
-
+        
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 val stlPath = renderer.renderToSTL(file, outputFile.toPath())
-
+                
                 SwingUtilities.invokeLater {
                     if (stlPath != null) {
                         updateStatus("✓ Exported to ${outputFile.name}")
@@ -406,26 +406,26 @@ class OpenSCADPreviewFileEditor(
             }
         }
     }
-
+    
     private fun export3MF() {
         if (!file.isValid) {
             updateStatus("✗ File is not valid")
             return
         }
-
+        
         // Show file save dialog
         val descriptor = FileSaverDescriptor("Export to 3MF", "Choose output 3MF file (preserves colors)", "3mf")
         val saveDialog = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
         val fileWrapper = saveDialog.save(file.parent, file.nameWithoutExtension + ".3mf") ?: return
-
+        
         val outputFile = fileWrapper.file
-
+        
         updateStatus("Exporting to ${outputFile.name}...")
-
+        
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 val threemfPath = renderer.renderTo3MF(file, outputFile.toPath())
-
+                
                 SwingUtilities.invokeLater {
                     if (threemfPath != null) {
                         updateStatus("✓ Exported to ${outputFile.name}")
@@ -457,28 +457,28 @@ class OpenSCADPreviewFileEditor(
             }
         }
     }
-
+    
     override fun getComponent(): JComponent = component
-
+    
     override fun getPreferredFocusedComponent(): JComponent? = viewerPanel
-
+    
     override fun getName(): String = "Preview"
-
+    
     override fun setState(state: FileEditorState) {}
-
+    
     override fun isModified(): Boolean = false
-
+    
     override fun isValid(): Boolean = file.isValid
-
+    
     override fun addPropertyChangeListener(listener: PropertyChangeListener) {}
-
+    
     override fun removePropertyChangeListener(listener: PropertyChangeListener) {}
-
+    
     override fun getCurrentLocation(): FileEditorLocation? = null
-
+    
     override fun dispose() {
         // Cleanup if needed
     }
-
+    
     override fun getFile(): VirtualFile = file
 }

--- a/src/main/kotlin/org/openscad/editor/OpenSCADPreviewFileEditor.kt
+++ b/src/main/kotlin/org/openscad/editor/OpenSCADPreviewFileEditor.kt
@@ -34,23 +34,23 @@ class OpenSCADPreviewFileEditor(
     private val project: Project,
     private val file: VirtualFile
 ) : UserDataHolderBase(), FileEditor {
-    
+
     private val logger = Logger.getInstance(OpenSCADPreviewFileEditor::class.java)
     private val settings = OpenSCADSettings.getInstance(project)
     private val renderer = OpenSCADRenderer(project)
     private val stlParser = STLParser()
     private val threemfParser = ThreeMFParser()
-    
+
     private val component: JComponent
     private val viewer: Any
     private val viewerPanel: JComponent
-    
+
     private val statusLabel = JLabel("Ready")
     private val renderButton = JButton("Render")
     private val resetViewButton = JButton("Reset View")
     private val previewModeButton = JButton("Preview: 3D ▼")
     private var currentPreviewMode = PreviewMode.SOLID_3D
-    
+
     private enum class PreviewMode(val displayName: String) {
         SOLID_3D("3D"),
         WIREFRAME("Wireframe"),
@@ -58,17 +58,29 @@ class OpenSCADPreviewFileEditor(
     }
     private val exportButton = JButton("Export ▼")
     private val autoRenderCheckbox = JCheckBox("auto-refresh")
-    
+
     private var isRendering = false
-    
+
     init {
-        // Initialize viewer - always use simple wireframe viewer for now
-        // JOGL has issues with ARM64 Mac (Apple Silicon) native libraries
-        val v = STLViewerPanel()
-        viewerPanel = v
-        viewer = v
-        logger.info("Initialized simple wireframe viewer")
-        
+        // Initialize viewer based on hardware acceleration setting
+        val (panel, viewerInstance) = if (settings.useHardwareAcceleration) {
+            try {
+                val v = STLViewer3D(project)
+                logger.info("Initialized hardware-accelerated JOGL viewer")
+                Pair(v as JComponent, v as Any)
+            } catch (e: Exception) {
+                logger.warn("Failed to initialize JOGL viewer, falling back to software renderer", e)
+                val v = STLViewerPanel()
+                Pair(v as JComponent, v as Any)
+            }
+        } else {
+            val v = STLViewerPanel()
+            logger.info("Initialized software renderer")
+            Pair(v as JComponent, v as Any)
+        }
+        viewerPanel = panel
+        viewer = viewerInstance
+
         // Create main component
         component = JPanel(BorderLayout()).apply {
             // Toolbar
@@ -82,30 +94,39 @@ class OpenSCADPreviewFileEditor(
             toolbar.add(autoRenderCheckbox)
             toolbar.add(Box.createHorizontalStrut(10))
             toolbar.add(statusLabel)
-            
+
             add(toolbar, BorderLayout.NORTH)
             add(viewerPanel, BorderLayout.CENTER)
         }
-        
+
         // Initialize auto-refresh from settings
         autoRenderCheckbox.isSelected = settings.autoRenderOnSave
-        
+
         setupListeners()
         checkOpenSCADAvailability()
     }
-    
+
     private fun setupListeners() {
         renderButton.addActionListener {
             renderForCurrentMode()
         }
-        
+
         resetViewButton.addActionListener {
-            (viewer as? STLViewerPanel)?.resetView()
+            when (viewer) {
+                is STLViewer3D -> viewer.resetView()
+                is STLViewerPanel -> viewer.resetView()
+            }
         }
-        
+
         previewModeButton.addActionListener {
             val popup = JPopupMenu()
-            PreviewMode.values().forEach { mode ->
+            val availableModes = if (viewer is STLViewerPanel) {
+                PreviewMode.values().toList()
+            } else {
+                // JOGL viewer only supports solid 3D mode
+                listOf(PreviewMode.SOLID_3D)
+            }
+            availableModes.forEach { mode ->
                 popup.add(JMenuItem(mode.displayName).apply {
                     addActionListener {
                         setPreviewMode(mode)
@@ -114,7 +135,7 @@ class OpenSCADPreviewFileEditor(
             }
             popup.show(previewModeButton, 0, previewModeButton.height)
         }
-        
+
         exportButton.addActionListener { e ->
             val popup = JPopupMenu()
             popup.add(JMenuItem("Export STL").apply {
@@ -125,14 +146,14 @@ class OpenSCADPreviewFileEditor(
             })
             popup.show(exportButton, 0, exportButton.height)
         }
-        
+
         autoRenderCheckbox.addActionListener {
             settings.autoRenderOnSave = autoRenderCheckbox.isSelected
             if (autoRenderCheckbox.isSelected) {
                 renderForCurrentMode()
             }
         }
-        
+
         // Listen for file save events
         val connection = project.messageBus.connect()
         connection.subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, object : FileEditorManagerListener {
@@ -140,7 +161,7 @@ class OpenSCADPreviewFileEditor(
                 // Cleanup when file is closed
             }
         })
-        
+
         // Listen for file save events using bulk file listener
         connection.subscribe(com.intellij.openapi.vfs.VirtualFileManager.VFS_CHANGES,
             object : BulkFileListener {
@@ -157,7 +178,7 @@ class OpenSCADPreviewFileEditor(
             }
         )
     }
-    
+
     private fun renderForCurrentMode() {
         when (currentPreviewMode) {
             PreviewMode.SOLID_3D -> {
@@ -165,15 +186,29 @@ class OpenSCADPreviewFileEditor(
                 renderFile()
             }
             PreviewMode.WIREFRAME -> {
-                (viewer as? STLViewerPanel)?.setWireframe(true)
-                renderFile()
+                if (viewer is STLViewerPanel) {
+                    viewer.setWireframe(true)
+                    renderFile()
+                } else {
+                    // JOGL viewer doesn't support wireframe, fall back to solid 3D
+                    currentPreviewMode = PreviewMode.SOLID_3D
+                    previewModeButton.text = "Preview: ${PreviewMode.SOLID_3D.displayName} ▼"
+                    renderFile()
+                }
             }
             PreviewMode.OPENSCAD_DEBUG -> {
-                renderDebugPreview()
+                if (viewer is STLViewerPanel) {
+                    renderDebugPreview()
+                } else {
+                    // JOGL viewer doesn't support debug preview, fall back to solid 3D
+                    currentPreviewMode = PreviewMode.SOLID_3D
+                    previewModeButton.text = "Preview: ${PreviewMode.SOLID_3D.displayName} ▼"
+                    renderFile()
+                }
             }
         }
     }
-    
+
     private fun checkOpenSCADAvailability() {
         if (!renderer.isOpenSCADAvailable()) {
             updateStatus("⚠️ OpenSCAD not found. Configure in Settings → Tools → OpenSCAD")
@@ -182,51 +217,57 @@ class OpenSCADPreviewFileEditor(
             updateStatus("✓ Ready to render")
         }
     }
-    
+
     private fun renderFile() {
         if (isRendering) {
             updateStatus("Already rendering...")
             return
         }
-        
+
         if (!file.isValid) {
             updateStatus("✗ File is not valid")
             return
         }
-        
+
         isRendering = true
         renderButton.isEnabled = false
         updateStatus("Rendering ${file.name}...")
-        
+
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 // Try 3MF first (preserves colors from color() statements)
                 logger.info("Starting 3MF render for ${file.name}")
                 val threemfPath = renderer.renderTo3MF(file)
-                
+
                 if (threemfPath != null) {
                     val coloredModel = threemfParser.parse(threemfPath)
-                    
+
                     if (coloredModel != null && coloredModel.triangles.isNotEmpty()) {
                         logger.info("3MF parsed: ${coloredModel.triangles.size} triangles")
                         SwingUtilities.invokeLater {
-                            (viewer as? STLViewerPanel)?.setColoredModel(coloredModel)
+                            when (viewer) {
+                                is STLViewer3D -> viewer.setColoredModel(coloredModel)
+                                is STLViewerPanel -> viewer.setColoredModel(coloredModel)
+                            }
                             updateStatus("✓ Rendered with colors (${coloredModel.triangles.size} triangles)")
                         }
                         return@executeOnPooledThread
                     }
                 }
-                
+
                 // Fall back to STL if 3MF fails
                 logger.info("Falling back to STL render")
                 val stlPath = renderer.renderToSTL(file)
-                
+
                 if (stlPath != null) {
                     val model = stlParser.parse(stlPath)
-                    
+
                     SwingUtilities.invokeLater {
                         if (model != null) {
-                            (viewer as? STLViewerPanel)?.setModel(model)
+                            when (viewer) {
+                                is STLViewer3D -> viewer.setModel(model)
+                                is STLViewerPanel -> viewer.setModel(model)
+                            }
                             updateStatus("✓ Rendered (${model.triangles.size} triangles)")
                         } else {
                             updateStatus("✗ Failed to parse STL")
@@ -250,50 +291,36 @@ class OpenSCADPreviewFileEditor(
             }
         }
     }
-    
+
     private fun updateStatus(message: String) {
         SwingUtilities.invokeLater {
             statusLabel.text = message
         }
     }
-    
+
     private fun setPreviewMode(mode: PreviewMode) {
         currentPreviewMode = mode
         previewModeButton.text = "Preview: ${mode.displayName} ▼"
-        
-        when (mode) {
-            PreviewMode.SOLID_3D -> {
-                (viewer as? STLViewerPanel)?.setWireframe(false)
-                // Re-render to show 3D view
-                renderFile()
-            }
-            PreviewMode.WIREFRAME -> {
-                (viewer as? STLViewerPanel)?.setWireframe(true)
-                renderFile()
-            }
-            PreviewMode.OPENSCAD_DEBUG -> {
-                renderDebugPreview()
-            }
-        }
+        renderForCurrentMode()
     }
-    
+
     private fun renderDebugPreview() {
         if (isRendering) {
             updateStatus("Already rendering...")
             return
         }
-        
+
         if (!file.isValid) {
             updateStatus("✗ File is not valid")
             return
         }
-        
+
         val viewerPanel = viewer as? STLViewerPanel
-        
+
         isRendering = true
         renderButton.isEnabled = false
         updateStatus("Rendering debug preview...")
-        
+
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 // Get current view parameters for camera synchronization
@@ -306,7 +333,7 @@ class OpenSCADPreviewFileEditor(
                     )
                 }
                 val pngPath = renderer.renderToPNG(file, 1024, 768, cameraParams)
-                
+
                 SwingUtilities.invokeLater {
                     if (pngPath != null) {
                         viewerPanel?.setPreviewImage(pngPath)
@@ -328,26 +355,26 @@ class OpenSCADPreviewFileEditor(
             }
         }
     }
-    
+
     private fun exportSTL() {
         if (!file.isValid) {
             updateStatus("✗ File is not valid")
             return
         }
-        
+
         // Show file save dialog
         val descriptor = FileSaverDescriptor("Export to STL", "Choose output STL file", "stl")
         val saveDialog = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
         val fileWrapper = saveDialog.save(file.parent, file.nameWithoutExtension + ".stl") ?: return
-        
+
         val outputFile = fileWrapper.file
-        
+
         updateStatus("Exporting to ${outputFile.name}...")
-        
+
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 val stlPath = renderer.renderToSTL(file, outputFile.toPath())
-                
+
                 SwingUtilities.invokeLater {
                     if (stlPath != null) {
                         updateStatus("✓ Exported to ${outputFile.name}")
@@ -379,26 +406,26 @@ class OpenSCADPreviewFileEditor(
             }
         }
     }
-    
+
     private fun export3MF() {
         if (!file.isValid) {
             updateStatus("✗ File is not valid")
             return
         }
-        
+
         // Show file save dialog
         val descriptor = FileSaverDescriptor("Export to 3MF", "Choose output 3MF file (preserves colors)", "3mf")
         val saveDialog = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
         val fileWrapper = saveDialog.save(file.parent, file.nameWithoutExtension + ".3mf") ?: return
-        
+
         val outputFile = fileWrapper.file
-        
+
         updateStatus("Exporting to ${outputFile.name}...")
-        
+
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 val threemfPath = renderer.renderTo3MF(file, outputFile.toPath())
-                
+
                 SwingUtilities.invokeLater {
                     if (threemfPath != null) {
                         updateStatus("✓ Exported to ${outputFile.name}")
@@ -430,28 +457,28 @@ class OpenSCADPreviewFileEditor(
             }
         }
     }
-    
+
     override fun getComponent(): JComponent = component
-    
+
     override fun getPreferredFocusedComponent(): JComponent? = viewerPanel
-    
+
     override fun getName(): String = "Preview"
-    
+
     override fun setState(state: FileEditorState) {}
-    
+
     override fun isModified(): Boolean = false
-    
+
     override fun isValid(): Boolean = file.isValid
-    
+
     override fun addPropertyChangeListener(listener: PropertyChangeListener) {}
-    
+
     override fun removePropertyChangeListener(listener: PropertyChangeListener) {}
-    
+
     override fun getCurrentLocation(): FileEditorLocation? = null
-    
+
     override fun dispose() {
         // Cleanup if needed
     }
-    
+
     override fun getFile(): VirtualFile = file
 }

--- a/src/main/kotlin/org/openscad/preview/OpenSCADPreviewToolWindow.kt
+++ b/src/main/kotlin/org/openscad/preview/OpenSCADPreviewToolWindow.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.fileChooser.FileChooserFactory
 import com.intellij.openapi.fileChooser.FileSaverDescriptor
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import org.openscad.settings.OpenSCADSettings
 import java.awt.BorderLayout
 import java.awt.FlowLayout
 import javax.swing.*
@@ -33,41 +34,49 @@ class OpenSCADPreviewToolWindowFactory : ToolWindowFactory {
  * Main preview panel containing the STL viewer and controls
  */
 class OpenSCADPreviewPanel(private val project: Project) : JPanel(BorderLayout()) {
-    
+
     private val logger = Logger.getInstance(OpenSCADPreviewPanel::class.java)
     private val renderer = OpenSCADRenderer(project)
     private val stlParser = STLParser()
     private val threemfParser = ThreeMFParser()
     private val viewerPanel: JComponent
     private val viewer: Any // Can be STLViewer3D or STLViewerPanel
-    
+
     private val statusLabel = JLabel("Ready")
     private val renderButton = JButton("Render")
     private val resetViewButton = JButton("Reset View")
     private val debugPreviewButton = JButton("Debug Preview")
     private val exportSTLButton = JButton("Export STL")
-    
+
     private var currentFile: VirtualFile? = null
     private var isRendering = false
-    
+
     init {
-        // Try to initialize JOGL viewer, fallback to simple viewer
-        val (panel, viewerInstance) = try {
-            val v = STLViewer3D(project)
-            Pair(v as JComponent, v)
-        } catch (e: Exception) {
-            logger.warn("Failed to initialize JOGL viewer, falling back to simple viewer", e)
+        // Initialize viewer based on hardware acceleration setting
+        val settings = OpenSCADSettings.getInstance(project)
+        val (panel, viewerInstance) = if (settings.useHardwareAcceleration) {
+            try {
+                val v = STLViewer3D(project)
+                logger.info("Initialized hardware-accelerated JOGL viewer")
+                Pair(v as JComponent, v as Any)
+            } catch (e: Exception) {
+                logger.warn("Failed to initialize JOGL viewer, falling back to software renderer", e)
+                val v = STLViewerPanel()
+                Pair(v as JComponent, v as Any)
+            }
+        } else {
             val v = STLViewerPanel()
-            Pair(v as JComponent, v)
+            logger.info("Initialized software renderer")
+            Pair(v as JComponent, v as Any)
         }
         viewerPanel = panel
         viewer = viewerInstance
-        
+
         setupUI()
         setupListeners()
         checkOpenSCADAvailability()
     }
-    
+
     private fun setupUI() {
         // Toolbar
         val toolbar = JPanel(FlowLayout(FlowLayout.LEFT))
@@ -77,31 +86,37 @@ class OpenSCADPreviewPanel(private val project: Project) : JPanel(BorderLayout()
         toolbar.add(exportSTLButton)
         toolbar.add(Box.createHorizontalStrut(20))
         toolbar.add(statusLabel)
-        
+
         add(toolbar, BorderLayout.NORTH)
         add(viewerPanel, BorderLayout.CENTER)
-        
+
         // Button actions
         renderButton.addActionListener {
             currentFile?.let { renderCurrentFile(it) }
         }
-        
+
         resetViewButton.addActionListener {
             when (viewer) {
                 is STLViewer3D -> viewer.resetView()
                 is STLViewerPanel -> viewer.resetView()
             }
         }
-        
+
         exportSTLButton.addActionListener {
             currentFile?.let { exportSTL(it) }
         }
-        
+
         debugPreviewButton.addActionListener {
             currentFile?.let { renderDebugPreview(it) }
         }
+
+        // Debug preview requires STLViewerPanel features (camera sync, image preview)
+        if (viewer !is STLViewerPanel) {
+            debugPreviewButton.isEnabled = false
+            debugPreviewButton.toolTipText = "Debug preview requires software renderer"
+        }
     }
-    
+
     private fun setupListeners() {
         // Listen for file editor changes
         project.messageBus.connect().subscribe(
@@ -116,14 +131,14 @@ class OpenSCADPreviewPanel(private val project: Project) : JPanel(BorderLayout()
                 }
             }
         )
-        
+
         // Check currently open file
         val currentEditor = FileEditorManager.getInstance(project).selectedFiles.firstOrNull()
         if (currentEditor?.extension == "scad") {
             currentFile = currentEditor
         }
     }
-    
+
     private fun checkOpenSCADAvailability() {
         if (!renderer.isOpenSCADAvailable()) {
             updateStatus("⚠️ OpenSCAD not found. Please install OpenSCAD.")
@@ -132,29 +147,29 @@ class OpenSCADPreviewPanel(private val project: Project) : JPanel(BorderLayout()
             updateStatus("✓ OpenSCAD found. Ready to render.")
         }
     }
-    
+
     private fun renderCurrentFile(file: VirtualFile) {
         if (isRendering) {
             updateStatus("Already rendering...")
             return
         }
-        
+
         isRendering = true
         renderButton.isEnabled = false
         updateStatus("Rendering ${file.name}...")
-        
+
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 // Try 3MF first (preserves colors from color() statements)
                 logger.info("Starting 3MF render for ${file.name}")
                 val threemfPath = renderer.renderTo3MF(file)
                 logger.info("3MF render result: $threemfPath")
-                
+
                 if (threemfPath != null) {
                     logger.info("Parsing 3MF file...")
                     val coloredModel = threemfParser.parse(threemfPath)
                     logger.info("3MF parse result: ${coloredModel?.triangles?.size ?: "null"} triangles")
-                    
+
                     if (coloredModel != null && coloredModel.triangles.isNotEmpty()) {
                         val uniqueColors = coloredModel.triangles.map { it.color }.distinct()
                         logger.info("Unique colors in model: ${uniqueColors.size} - $uniqueColors")
@@ -172,13 +187,13 @@ class OpenSCADPreviewPanel(private val project: Project) : JPanel(BorderLayout()
                 } else {
                     logger.warn("3MF render returned null, falling back to STL")
                 }
-                
+
                 // Fall back to STL if 3MF fails
                 val stlPath = renderer.renderToSTL(file)
-                
+
                 if (stlPath != null) {
                     val model = stlParser.parse(stlPath)
-                    
+
                     SwingUtilities.invokeLater {
                         if (model != null) {
                             when (viewer) {
@@ -211,27 +226,27 @@ class OpenSCADPreviewPanel(private val project: Project) : JPanel(BorderLayout()
             }
         }
     }
-    
+
     private fun updateStatus(message: String) {
         SwingUtilities.invokeLater {
             statusLabel.text = message
             logger.info(message)
         }
     }
-    
+
     private fun clearModel() {
         when (viewer) {
             is STLViewer3D -> viewer.setModel(null)
             is STLViewerPanel -> viewer.setModel(null)
         }
     }
-    
+
     private fun renderDebugPreview(file: VirtualFile) {
         if (isRendering) {
             updateStatus("Already rendering...")
             return
         }
-        
+
         // Check if already showing debug preview, toggle back to 3D view
         val viewerPanel = viewer as? STLViewerPanel
         if (viewerPanel?.isShowingImagePreview() == true) {
@@ -240,11 +255,11 @@ class OpenSCADPreviewPanel(private val project: Project) : JPanel(BorderLayout()
             updateStatus("✓ Switched to 3D view")
             return
         }
-        
+
         isRendering = true
         debugPreviewButton.isEnabled = false
         updateStatus("Rendering debug preview...")
-        
+
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 // Get current view parameters for camera synchronization
@@ -257,7 +272,7 @@ class OpenSCADPreviewPanel(private val project: Project) : JPanel(BorderLayout()
                     )
                 }
                 val pngPath = renderer.renderToPNG(file, 1024, 768, cameraParams)
-                
+
                 SwingUtilities.invokeLater {
                     if (pngPath != null) {
                         (viewer as? STLViewerPanel)?.setPreviewImage(pngPath)
@@ -280,21 +295,21 @@ class OpenSCADPreviewPanel(private val project: Project) : JPanel(BorderLayout()
             }
         }
     }
-    
+
     private fun exportSTL(file: VirtualFile) {
         // Show file save dialog
         val descriptor = FileSaverDescriptor("Export to STL", "Choose output STL file", "stl")
         val saveDialog = FileChooserFactory.getInstance().createSaveFileDialog(descriptor, project)
         val fileWrapper = saveDialog.save(file.parent, file.nameWithoutExtension + ".stl") ?: return
-        
+
         val outputFile = fileWrapper.file
-        
+
         updateStatus("Exporting to ${outputFile.name}...")
-        
+
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
                 val stlPath = renderer.renderToSTL(file, outputFile.toPath())
-                
+
                 SwingUtilities.invokeLater {
                     if (stlPath != null) {
                         updateStatus("✓ Exported to ${outputFile.name}")

--- a/src/main/kotlin/org/openscad/preview/STLViewer3D.kt
+++ b/src/main/kotlin/org/openscad/preview/STLViewer3D.kt
@@ -16,43 +16,43 @@ import kotlin.math.sin
  * Provides hardware-accelerated rendering with lighting and smooth shading
  */
 class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEventListener {
-
+    
     private var model: STLParser.STLModel? = null
     private var coloredModel: ThreeMFParser.ColoredModel? = null
     private val canvas: GLCanvas
     private val animator: FPSAnimator
-
+    
     // Camera/view parameters
     private var rotationX = 30.0f
     private var rotationY = 45.0f
     private var zoom = 1.0f
     private var panX = 0.0f
     private var panY = 0.0f
-
+    
     // Mouse interaction
     private var lastMouseX = 0
     private var lastMouseY = 0
     private var isDragging = false
     private var isPanning = false
-
+    
     init {
         val caps = GLCapabilities(GLProfile.get(GLProfile.GL2))
         caps.doubleBuffered = true
         caps.hardwareAccelerated = true
-
+        
         canvas = GLCanvas(caps)
         canvas.addGLEventListener(this)
-
+        
         // Setup mouse controls
         setupMouseControls()
-
+        
         add(canvas, BorderLayout.CENTER)
-
+        
         // Start animation loop
         animator = FPSAnimator(canvas, 60)
         animator.start()
     }
-
+    
     private fun setupMouseControls() {
         canvas.addMouseListener(object : MouseAdapter() {
             override fun mousePressed(e: MouseEvent) {
@@ -61,18 +61,18 @@ class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEven
                 isDragging = e.button == MouseEvent.BUTTON1
                 isPanning = e.button == MouseEvent.BUTTON3
             }
-
+            
             override fun mouseReleased(e: MouseEvent) {
                 isDragging = false
                 isPanning = false
             }
         })
-
+        
         canvas.addMouseMotionListener(object : MouseMotionAdapter() {
             override fun mouseDragged(e: MouseEvent) {
                 val dx = e.x - lastMouseX
                 val dy = e.y - lastMouseY
-
+                
                 if (isDragging) {
                     rotationY += dx * 0.5f
                     rotationX += dy * 0.5f
@@ -80,33 +80,33 @@ class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEven
                     panX += dx * 0.01f
                     panY -= dy * 0.01f
                 }
-
+                
                 lastMouseX = e.x
                 lastMouseY = e.y
             }
         })
-
+        
         canvas.addMouseWheelListener { e ->
             val zoomFactor = if (e.wheelRotation < 0) 1.1f else 0.9f
             zoom *= zoomFactor
             zoom = zoom.coerceIn(0.1f, 10.0f)
         }
     }
-
+    
     fun setModel(model: STLParser.STLModel?) {
         this.model = model
         this.coloredModel = null
         resetView()
         repaint()
     }
-
+    
     fun setColoredModel(model: ThreeMFParser.ColoredModel?) {
         this.coloredModel = model
         this.model = null
         resetView()
         repaint()
     }
-
+    
     fun resetView() {
         rotationX = 30.0f
         rotationY = 45.0f
@@ -115,10 +115,10 @@ class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEven
         panY = 0.0f
         repaint()
     }
-
+    
     override fun init(drawable: GLAutoDrawable) {
         val gl = drawable.gl.gL2
-
+        
         // Enable depth testing
         gl.glEnable(GL.GL_DEPTH_TEST)
         gl.glDepthFunc(GL.GL_LEQUAL)
@@ -151,88 +151,88 @@ class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEven
 
         // Enable smooth shading
         gl.glShadeModel(GL2.GL_SMOOTH)
-
+        
         // Background color - OpenSCAD default (light gray)
         gl.glClearColor(0.898f, 0.898f, 0.898f, 1.0f)
     }
-
+    
     override fun display(drawable: GLAutoDrawable) {
         val gl = drawable.gl.gL2
-
+        
         gl.glClear(GL.GL_COLOR_BUFFER_BIT or GL.GL_DEPTH_BUFFER_BIT)
         gl.glLoadIdentity()
-
+        
         // Setup camera
         gl.glTranslatef(panX, panY, -5.0f * zoom)
         gl.glRotatef(rotationX, 1.0f, 0.0f, 0.0f)
         gl.glRotatef(rotationY, 0.0f, 1.0f, 0.0f)
-
+        
         // Draw grid first (under the model)
         val settings = OpenSCADSettings.getInstance(project)
         if (settings.showGrid) {
             drawGrid(gl, settings.gridSize, settings.gridSpacing)
         }
-
+        
         val currentColoredModel = coloredModel
         val currentModel = model
-
+        
         if (currentColoredModel != null) {
             drawColoredModel(gl, currentColoredModel)
         } else if (currentModel != null) {
             drawModel(gl, currentModel)
         }
     }
-
+    
     private fun drawModel(gl: GL2, model: STLParser.STLModel) {
         // Center and scale model
         val center = model.bounds.center
         val size = model.bounds.size
         val maxSize = maxOf(size.x, size.y, size.z)
         val scale = 2.0f / maxSize
-
+        
         gl.glPushMatrix()
         gl.glScalef(scale, scale, scale)
         gl.glTranslatef(-center.x, -center.y, -center.z)
-
+        
         // Set material properties - OpenSCAD default (coral/orange)
         val matAmbient = floatArrayOf(0.95f, 0.55f, 0.35f, 1.0f)
         val matDiffuse = floatArrayOf(0.95f, 0.55f, 0.35f, 1.0f)
         val matSpecular = floatArrayOf(0.3f, 0.3f, 0.3f, 1.0f)
         val matShininess = floatArrayOf(64.0f)
-
+        
         gl.glMaterialfv(GL.GL_FRONT_AND_BACK, GL2.GL_AMBIENT, matAmbient, 0)
         gl.glMaterialfv(GL.GL_FRONT_AND_BACK, GL2.GL_DIFFUSE, matDiffuse, 0)
         gl.glMaterialfv(GL.GL_FRONT_AND_BACK, GL2.GL_SPECULAR, matSpecular, 0)
         gl.glMaterialfv(GL.GL_FRONT_AND_BACK, GL2.GL_SHININESS, matShininess, 0)
-
+        
         // Draw triangles
         gl.glBegin(GL2.GL_TRIANGLES)
         model.triangles.forEach { triangle ->
             // Set normal for lighting
             gl.glNormal3f(triangle.normal.x, triangle.normal.y, triangle.normal.z)
-
+            
             // Draw vertices
             gl.glVertex3f(triangle.v1.x, triangle.v1.y, triangle.v1.z)
             gl.glVertex3f(triangle.v2.x, triangle.v2.y, triangle.v2.z)
             gl.glVertex3f(triangle.v3.x, triangle.v3.y, triangle.v3.z)
         }
         gl.glEnd()
-
+        
         gl.glPopMatrix()
-
+        
         // Draw axes
         drawAxes(gl)
     }
-
+    
     private fun drawGrid(gl: GL2, gridSize: Float, gridSpacing: Float) {
         gl.glDisable(GL2.GL_LIGHTING)
         gl.glDisable(GL.GL_DEPTH_TEST)
-
+        
         val halfSize = gridSize / 2.0f
         val numLines = (gridSize / gridSpacing).toInt()
-
+        
         gl.glBegin(GL.GL_LINES)
-
+        
         // Grid lines parallel to X axis
         for (i in -numLines..numLines) {
             val y = i * gridSpacing
@@ -246,7 +246,7 @@ class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEven
             gl.glVertex3f(-halfSize, y, 0.0f)
             gl.glVertex3f(halfSize, y, 0.0f)
         }
-
+        
         // Grid lines parallel to Y axis
         for (i in -numLines..numLines) {
             val x = i * gridSpacing
@@ -260,34 +260,34 @@ class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEven
             gl.glVertex3f(x, -halfSize, 0.0f)
             gl.glVertex3f(x, halfSize, 0.0f)
         }
-
+        
         gl.glEnd()
-
+        
         gl.glEnable(GL.GL_DEPTH_TEST)
         gl.glEnable(GL2.GL_LIGHTING)
     }
-
+    
     private fun drawColoredModel(gl: GL2, model: ThreeMFParser.ColoredModel) {
         // Center and scale model
         val center = model.bounds.center
         val size = model.bounds.size
         val maxSize = maxOf(size.x, size.y, size.z)
         val scale = if (maxSize > 0) 2.0f / maxSize else 1.0f
-
+        
         gl.glPushMatrix()
         gl.glScalef(scale, scale, scale)
         gl.glTranslatef(-center.x, -center.y, -center.z)
-
+        
         // Enable color material so vertex colors affect lighting
         gl.glEnable(GL2.GL_COLOR_MATERIAL)
         gl.glColorMaterial(GL.GL_FRONT_AND_BACK, GL2.GL_AMBIENT_AND_DIFFUSE)
-
+        
         // Set specular properties (shared for all triangles)
         val matSpecular = floatArrayOf(0.3f, 0.3f, 0.3f, 1.0f)
         val matShininess = floatArrayOf(64.0f)
         gl.glMaterialfv(GL.GL_FRONT_AND_BACK, GL2.GL_SPECULAR, matSpecular, 0)
         gl.glMaterialfv(GL.GL_FRONT_AND_BACK, GL2.GL_SHININESS, matShininess, 0)
-
+        
         // Draw triangles with per-triangle colors
         gl.glBegin(GL2.GL_TRIANGLES)
         model.triangles.forEach { triangle ->
@@ -297,69 +297,69 @@ class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEven
                 triangle.color.green / 255.0f,
                 triangle.color.blue / 255.0f
             )
-
+            
             // Set normal for lighting
             gl.glNormal3f(triangle.normal.x, triangle.normal.y, triangle.normal.z)
-
+            
             // Draw vertices
             gl.glVertex3f(triangle.v1.x, triangle.v1.y, triangle.v1.z)
             gl.glVertex3f(triangle.v2.x, triangle.v2.y, triangle.v2.z)
             gl.glVertex3f(triangle.v3.x, triangle.v3.y, triangle.v3.z)
         }
         gl.glEnd()
-
+        
         // Disable color material to restore state
         gl.glDisable(GL2.GL_COLOR_MATERIAL)
-
+        
         gl.glPopMatrix()
-
+        
         // Draw axes
         drawAxes(gl)
     }
-
+    
     private fun drawAxes(gl: GL2) {
         gl.glDisable(GL2.GL_LIGHTING)
         gl.glBegin(GL.GL_LINES)
-
+        
         // X axis (red)
         gl.glColor3f(1.0f, 0.0f, 0.0f)
         gl.glVertex3f(0.0f, 0.0f, 0.0f)
         gl.glVertex3f(1.0f, 0.0f, 0.0f)
-
+        
         // Y axis (green)
         gl.glColor3f(0.0f, 1.0f, 0.0f)
         gl.glVertex3f(0.0f, 0.0f, 0.0f)
         gl.glVertex3f(0.0f, 1.0f, 0.0f)
-
+        
         // Z axis (blue)
         gl.glColor3f(0.0f, 0.0f, 1.0f)
         gl.glVertex3f(0.0f, 0.0f, 0.0f)
         gl.glVertex3f(0.0f, 0.0f, 1.0f)
-
+        
         gl.glEnd()
         gl.glEnable(GL2.GL_LIGHTING)
     }
-
+    
     override fun reshape(drawable: GLAutoDrawable, x: Int, y: Int, width: Int, height: Int) {
         val gl = drawable.gl.gL2
-
+        
         gl.glViewport(0, 0, width, height)
         gl.glMatrixMode(GL2.GL_PROJECTION)
         gl.glLoadIdentity()
-
+        
         val aspect = width.toFloat() / height.toFloat()
         val fovy = 45.0
         val zNear = 0.1
         val zFar = 100.0
-
+        
         val fH = Math.tan(fovy / 360.0 * Math.PI) * zNear
         val fW = fH * aspect
         gl.glFrustum(-fW, fW, -fH, fH, zNear, zFar)
-
+        
         gl.glMatrixMode(GL2.GL_MODELVIEW)
         gl.glLoadIdentity()
     }
-
+    
     override fun dispose(drawable: GLAutoDrawable) {
         animator.stop()
     }

--- a/src/main/kotlin/org/openscad/preview/STLViewer3D.kt
+++ b/src/main/kotlin/org/openscad/preview/STLViewer3D.kt
@@ -16,43 +16,43 @@ import kotlin.math.sin
  * Provides hardware-accelerated rendering with lighting and smooth shading
  */
 class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEventListener {
-    
+
     private var model: STLParser.STLModel? = null
     private var coloredModel: ThreeMFParser.ColoredModel? = null
     private val canvas: GLCanvas
     private val animator: FPSAnimator
-    
+
     // Camera/view parameters
     private var rotationX = 30.0f
     private var rotationY = 45.0f
     private var zoom = 1.0f
     private var panX = 0.0f
     private var panY = 0.0f
-    
+
     // Mouse interaction
     private var lastMouseX = 0
     private var lastMouseY = 0
     private var isDragging = false
     private var isPanning = false
-    
+
     init {
         val caps = GLCapabilities(GLProfile.get(GLProfile.GL2))
         caps.doubleBuffered = true
         caps.hardwareAccelerated = true
-        
+
         canvas = GLCanvas(caps)
         canvas.addGLEventListener(this)
-        
+
         // Setup mouse controls
         setupMouseControls()
-        
+
         add(canvas, BorderLayout.CENTER)
-        
+
         // Start animation loop
         animator = FPSAnimator(canvas, 60)
         animator.start()
     }
-    
+
     private fun setupMouseControls() {
         canvas.addMouseListener(object : MouseAdapter() {
             override fun mousePressed(e: MouseEvent) {
@@ -61,18 +61,18 @@ class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEven
                 isDragging = e.button == MouseEvent.BUTTON1
                 isPanning = e.button == MouseEvent.BUTTON3
             }
-            
+
             override fun mouseReleased(e: MouseEvent) {
                 isDragging = false
                 isPanning = false
             }
         })
-        
+
         canvas.addMouseMotionListener(object : MouseMotionAdapter() {
             override fun mouseDragged(e: MouseEvent) {
                 val dx = e.x - lastMouseX
                 val dy = e.y - lastMouseY
-                
+
                 if (isDragging) {
                     rotationY += dx * 0.5f
                     rotationX += dy * 0.5f
@@ -80,33 +80,33 @@ class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEven
                     panX += dx * 0.01f
                     panY -= dy * 0.01f
                 }
-                
+
                 lastMouseX = e.x
                 lastMouseY = e.y
             }
         })
-        
+
         canvas.addMouseWheelListener { e ->
             val zoomFactor = if (e.wheelRotation < 0) 1.1f else 0.9f
             zoom *= zoomFactor
             zoom = zoom.coerceIn(0.1f, 10.0f)
         }
     }
-    
+
     fun setModel(model: STLParser.STLModel?) {
         this.model = model
         this.coloredModel = null
         resetView()
         repaint()
     }
-    
+
     fun setColoredModel(model: ThreeMFParser.ColoredModel?) {
         this.coloredModel = model
         this.model = null
         resetView()
         repaint()
     }
-    
+
     fun resetView() {
         rotationX = 30.0f
         rotationY = 45.0f
@@ -115,114 +115,124 @@ class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEven
         panY = 0.0f
         repaint()
     }
-    
+
     override fun init(drawable: GLAutoDrawable) {
         val gl = drawable.gl.gL2
-        
+
         // Enable depth testing
         gl.glEnable(GL.GL_DEPTH_TEST)
         gl.glDepthFunc(GL.GL_LEQUAL)
-        
+
+        // Enable back-face culling (STL models are closed solids)
+        gl.glEnable(GL.GL_CULL_FACE)
+        gl.glCullFace(GL.GL_BACK)
+
         // Enable lighting
         gl.glEnable(GL2.GL_LIGHTING)
         gl.glEnable(GL2.GL_LIGHT0)
-        gl.glEnable(GL2.GL_COLOR_MATERIAL)
-        
+
         // Setup light
         val lightPos = floatArrayOf(1.0f, 1.0f, 1.0f, 0.0f)
-        val lightAmbient = floatArrayOf(0.3f, 0.3f, 0.3f, 1.0f)
-        val lightDiffuse = floatArrayOf(0.8f, 0.8f, 0.8f, 1.0f)
-        val lightSpecular = floatArrayOf(1.0f, 1.0f, 1.0f, 1.0f)
-        
+        val lightAmbient = floatArrayOf(0.2f, 0.2f, 0.2f, 1.0f)
+        val lightDiffuse = floatArrayOf(0.7f, 0.7f, 0.7f, 1.0f)
+        val lightSpecular = floatArrayOf(0.4f, 0.4f, 0.4f, 1.0f)
+
+        // Disable global ambient (defaults to 0.2, stacks on top of per-light ambient)
+        gl.glLightModelfv(GL2.GL_LIGHT_MODEL_AMBIENT, floatArrayOf(0.0f, 0.0f, 0.0f, 1.0f), 0)
+
         gl.glLightfv(GL2.GL_LIGHT0, GL2.GL_POSITION, lightPos, 0)
         gl.glLightfv(GL2.GL_LIGHT0, GL2.GL_AMBIENT, lightAmbient, 0)
         gl.glLightfv(GL2.GL_LIGHT0, GL2.GL_DIFFUSE, lightDiffuse, 0)
         gl.glLightfv(GL2.GL_LIGHT0, GL2.GL_SPECULAR, lightSpecular, 0)
-        
+
+        // Renormalize normals after model scaling (glScalef stretches normals,
+        // causing blown-out lighting without this)
+        gl.glEnable(GL2.GL_NORMALIZE)
+
         // Enable smooth shading
         gl.glShadeModel(GL2.GL_SMOOTH)
-        
+
         // Background color - OpenSCAD default (light gray)
         gl.glClearColor(0.898f, 0.898f, 0.898f, 1.0f)
     }
-    
+
     override fun display(drawable: GLAutoDrawable) {
         val gl = drawable.gl.gL2
-        
+
         gl.glClear(GL.GL_COLOR_BUFFER_BIT or GL.GL_DEPTH_BUFFER_BIT)
         gl.glLoadIdentity()
-        
+
         // Setup camera
         gl.glTranslatef(panX, panY, -5.0f * zoom)
         gl.glRotatef(rotationX, 1.0f, 0.0f, 0.0f)
         gl.glRotatef(rotationY, 0.0f, 1.0f, 0.0f)
-        
+
         // Draw grid first (under the model)
         val settings = OpenSCADSettings.getInstance(project)
         if (settings.showGrid) {
             drawGrid(gl, settings.gridSize, settings.gridSpacing)
         }
-        
+
         val currentColoredModel = coloredModel
         val currentModel = model
-        
+
         if (currentColoredModel != null) {
             drawColoredModel(gl, currentColoredModel)
         } else if (currentModel != null) {
             drawModel(gl, currentModel)
         }
     }
-    
+
     private fun drawModel(gl: GL2, model: STLParser.STLModel) {
         // Center and scale model
         val center = model.bounds.center
         val size = model.bounds.size
         val maxSize = maxOf(size.x, size.y, size.z)
         val scale = 2.0f / maxSize
-        
+
         gl.glPushMatrix()
         gl.glScalef(scale, scale, scale)
         gl.glTranslatef(-center.x, -center.y, -center.z)
-        
+
         // Set material properties - OpenSCAD default (coral/orange)
         val matAmbient = floatArrayOf(0.95f, 0.55f, 0.35f, 1.0f)
         val matDiffuse = floatArrayOf(0.95f, 0.55f, 0.35f, 1.0f)
-        val matSpecular = floatArrayOf(0.8f, 0.8f, 0.8f, 1.0f)
-        val matShininess = floatArrayOf(32.0f)
-        
-        gl.glMaterialfv(GL.GL_FRONT, GL2.GL_AMBIENT, matAmbient, 0)
-        gl.glMaterialfv(GL.GL_FRONT, GL2.GL_DIFFUSE, matDiffuse, 0)
-        gl.glMaterialfv(GL.GL_FRONT, GL2.GL_SPECULAR, matSpecular, 0)
-        gl.glMaterialfv(GL.GL_FRONT, GL2.GL_SHININESS, matShininess, 0)
-        
+        val matSpecular = floatArrayOf(0.3f, 0.3f, 0.3f, 1.0f)
+        val matShininess = floatArrayOf(64.0f)
+
+        gl.glMaterialfv(GL.GL_FRONT_AND_BACK, GL2.GL_AMBIENT, matAmbient, 0)
+        gl.glMaterialfv(GL.GL_FRONT_AND_BACK, GL2.GL_DIFFUSE, matDiffuse, 0)
+        gl.glMaterialfv(GL.GL_FRONT_AND_BACK, GL2.GL_SPECULAR, matSpecular, 0)
+        gl.glMaterialfv(GL.GL_FRONT_AND_BACK, GL2.GL_SHININESS, matShininess, 0)
+
         // Draw triangles
         gl.glBegin(GL2.GL_TRIANGLES)
         model.triangles.forEach { triangle ->
             // Set normal for lighting
             gl.glNormal3f(triangle.normal.x, triangle.normal.y, triangle.normal.z)
-            
+
             // Draw vertices
             gl.glVertex3f(triangle.v1.x, triangle.v1.y, triangle.v1.z)
             gl.glVertex3f(triangle.v2.x, triangle.v2.y, triangle.v2.z)
             gl.glVertex3f(triangle.v3.x, triangle.v3.y, triangle.v3.z)
         }
         gl.glEnd()
-        
+
         gl.glPopMatrix()
-        
+
         // Draw axes
         drawAxes(gl)
     }
-    
+
     private fun drawGrid(gl: GL2, gridSize: Float, gridSpacing: Float) {
         gl.glDisable(GL2.GL_LIGHTING)
         gl.glDisable(GL.GL_DEPTH_TEST)
-        
+
         val halfSize = gridSize / 2.0f
         val numLines = (gridSize / gridSpacing).toInt()
-        
+
         gl.glBegin(GL.GL_LINES)
-        
+
         // Grid lines parallel to X axis
         for (i in -numLines..numLines) {
             val y = i * gridSpacing
@@ -236,7 +246,7 @@ class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEven
             gl.glVertex3f(-halfSize, y, 0.0f)
             gl.glVertex3f(halfSize, y, 0.0f)
         }
-        
+
         // Grid lines parallel to Y axis
         for (i in -numLines..numLines) {
             val x = i * gridSpacing
@@ -250,34 +260,34 @@ class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEven
             gl.glVertex3f(x, -halfSize, 0.0f)
             gl.glVertex3f(x, halfSize, 0.0f)
         }
-        
+
         gl.glEnd()
-        
+
         gl.glEnable(GL.GL_DEPTH_TEST)
         gl.glEnable(GL2.GL_LIGHTING)
     }
-    
+
     private fun drawColoredModel(gl: GL2, model: ThreeMFParser.ColoredModel) {
         // Center and scale model
         val center = model.bounds.center
         val size = model.bounds.size
         val maxSize = maxOf(size.x, size.y, size.z)
         val scale = if (maxSize > 0) 2.0f / maxSize else 1.0f
-        
+
         gl.glPushMatrix()
         gl.glScalef(scale, scale, scale)
         gl.glTranslatef(-center.x, -center.y, -center.z)
-        
+
         // Enable color material so vertex colors affect lighting
         gl.glEnable(GL2.GL_COLOR_MATERIAL)
         gl.glColorMaterial(GL.GL_FRONT_AND_BACK, GL2.GL_AMBIENT_AND_DIFFUSE)
-        
+
         // Set specular properties (shared for all triangles)
-        val matSpecular = floatArrayOf(0.5f, 0.5f, 0.5f, 1.0f)
-        val matShininess = floatArrayOf(32.0f)
-        gl.glMaterialfv(GL.GL_FRONT, GL2.GL_SPECULAR, matSpecular, 0)
-        gl.glMaterialfv(GL.GL_FRONT, GL2.GL_SHININESS, matShininess, 0)
-        
+        val matSpecular = floatArrayOf(0.3f, 0.3f, 0.3f, 1.0f)
+        val matShininess = floatArrayOf(64.0f)
+        gl.glMaterialfv(GL.GL_FRONT_AND_BACK, GL2.GL_SPECULAR, matSpecular, 0)
+        gl.glMaterialfv(GL.GL_FRONT_AND_BACK, GL2.GL_SHININESS, matShininess, 0)
+
         // Draw triangles with per-triangle colors
         gl.glBegin(GL2.GL_TRIANGLES)
         model.triangles.forEach { triangle ->
@@ -287,69 +297,69 @@ class STLViewer3D(private val project: Project) : JPanel(BorderLayout()), GLEven
                 triangle.color.green / 255.0f,
                 triangle.color.blue / 255.0f
             )
-            
+
             // Set normal for lighting
             gl.glNormal3f(triangle.normal.x, triangle.normal.y, triangle.normal.z)
-            
+
             // Draw vertices
             gl.glVertex3f(triangle.v1.x, triangle.v1.y, triangle.v1.z)
             gl.glVertex3f(triangle.v2.x, triangle.v2.y, triangle.v2.z)
             gl.glVertex3f(triangle.v3.x, triangle.v3.y, triangle.v3.z)
         }
         gl.glEnd()
-        
+
         // Disable color material to restore state
         gl.glDisable(GL2.GL_COLOR_MATERIAL)
-        
+
         gl.glPopMatrix()
-        
+
         // Draw axes
         drawAxes(gl)
     }
-    
+
     private fun drawAxes(gl: GL2) {
         gl.glDisable(GL2.GL_LIGHTING)
         gl.glBegin(GL.GL_LINES)
-        
+
         // X axis (red)
         gl.glColor3f(1.0f, 0.0f, 0.0f)
         gl.glVertex3f(0.0f, 0.0f, 0.0f)
         gl.glVertex3f(1.0f, 0.0f, 0.0f)
-        
+
         // Y axis (green)
         gl.glColor3f(0.0f, 1.0f, 0.0f)
         gl.glVertex3f(0.0f, 0.0f, 0.0f)
         gl.glVertex3f(0.0f, 1.0f, 0.0f)
-        
+
         // Z axis (blue)
         gl.glColor3f(0.0f, 0.0f, 1.0f)
         gl.glVertex3f(0.0f, 0.0f, 0.0f)
         gl.glVertex3f(0.0f, 0.0f, 1.0f)
-        
+
         gl.glEnd()
         gl.glEnable(GL2.GL_LIGHTING)
     }
-    
+
     override fun reshape(drawable: GLAutoDrawable, x: Int, y: Int, width: Int, height: Int) {
         val gl = drawable.gl.gL2
-        
+
         gl.glViewport(0, 0, width, height)
         gl.glMatrixMode(GL2.GL_PROJECTION)
         gl.glLoadIdentity()
-        
+
         val aspect = width.toFloat() / height.toFloat()
         val fovy = 45.0
         val zNear = 0.1
         val zFar = 100.0
-        
+
         val fH = Math.tan(fovy / 360.0 * Math.PI) * zNear
         val fW = fH * aspect
         gl.glFrustum(-fW, fW, -fH, fH, zNear, zFar)
-        
+
         gl.glMatrixMode(GL2.GL_MODELVIEW)
         gl.glLoadIdentity()
     }
-    
+
     override fun dispose(drawable: GLAutoDrawable) {
         animator.stop()
     }

--- a/src/main/kotlin/org/openscad/settings/OpenSCADSettings.kt
+++ b/src/main/kotlin/org/openscad/settings/OpenSCADSettings.kt
@@ -13,33 +13,36 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 )
 @Service(Service.Level.PROJECT)
 class OpenSCADSettings : PersistentStateComponent<OpenSCADSettings> {
-    
+
     var openscadPath: String = ""
     var autoRenderOnSave: Boolean = false
     var renderTimeout: Int = 30 // seconds
-    
+
     // Rendering options
     var useFullRender: Boolean = false // Use --render instead of preview
     var autoCenter: Boolean = true // Use --autocenter
     var viewAll: Boolean = true // Use --viewall
-    
+
+    // Viewer settings
+    var useHardwareAcceleration: Boolean = false // Use JOGL hardware-accelerated viewer (experimental)
+
     // Preview grid settings
     var showGrid: Boolean = true // Show grid in 3D preview
     var gridSize: Float = 250.0f // Grid size in mm (250mm x 250mm default)
     var gridSpacing: Float = 10.0f // Grid line spacing in mm
-    
+
     // Library paths
     var libraryPaths: MutableList<String> = mutableListOf()
-    
+
     // Custom temp directory (empty = use system default, with Linux Flatpak-friendly fallback)
     var customTempDirectory: String = ""
-    
+
     override fun getState(): OpenSCADSettings = this
-    
+
     override fun loadState(state: OpenSCADSettings) {
         XmlSerializerUtil.copyBean(state, this)
     }
-    
+
     companion object {
         fun getInstance(project: Project): OpenSCADSettings {
             return project.service()

--- a/src/main/kotlin/org/openscad/settings/OpenSCADSettings.kt
+++ b/src/main/kotlin/org/openscad/settings/OpenSCADSettings.kt
@@ -13,11 +13,11 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 )
 @Service(Service.Level.PROJECT)
 class OpenSCADSettings : PersistentStateComponent<OpenSCADSettings> {
-
+    
     var openscadPath: String = ""
     var autoRenderOnSave: Boolean = false
     var renderTimeout: Int = 30 // seconds
-
+    
     // Rendering options
     var useFullRender: Boolean = false // Use --render instead of preview
     var autoCenter: Boolean = true // Use --autocenter
@@ -30,19 +30,19 @@ class OpenSCADSettings : PersistentStateComponent<OpenSCADSettings> {
     var showGrid: Boolean = true // Show grid in 3D preview
     var gridSize: Float = 250.0f // Grid size in mm (250mm x 250mm default)
     var gridSpacing: Float = 10.0f // Grid line spacing in mm
-
+    
     // Library paths
     var libraryPaths: MutableList<String> = mutableListOf()
-
+    
     // Custom temp directory (empty = use system default, with Linux Flatpak-friendly fallback)
     var customTempDirectory: String = ""
-
+    
     override fun getState(): OpenSCADSettings = this
-
+    
     override fun loadState(state: OpenSCADSettings) {
         XmlSerializerUtil.copyBean(state, this)
     }
-
+    
     companion object {
         fun getInstance(project: Project): OpenSCADSettings {
             return project.service()

--- a/src/main/kotlin/org/openscad/settings/OpenSCADSettingsConfigurable.kt
+++ b/src/main/kotlin/org/openscad/settings/OpenSCADSettingsConfigurable.kt
@@ -22,12 +22,12 @@ import javax.swing.JPanel
  * Settings UI for OpenSCAD plugin
  */
 class OpenSCADSettingsConfigurable(private val project: Project) : Configurable {
-
+    
     private val openscadPathField = TextFieldWithBrowseButton()
     private val autoRenderCheckbox = JBCheckBox("auto-refresh on file save")
     private val timeoutField = JBTextField()
     private val detectedPathLabel = JBLabel()
-
+    
     // Rendering options
     private val useFullRenderCheckbox = JBCheckBox("Use full render (slower, more accurate)")
     private val autoCenterCheckbox = JBCheckBox("Auto-center model")
@@ -40,16 +40,16 @@ class OpenSCADSettingsConfigurable(private val project: Project) : Configurable 
     private val showGridCheckbox = JBCheckBox("Show grid in preview")
     private val gridSizeField = JBTextField()
     private val gridSpacingField = JBTextField()
-
+    
     // Library paths
     private val libraryPathsField = JBTextArea()
     private val libraryPathsScrollPane = JBScrollPane(libraryPathsField)
-
+    
     // Temp directory
     private val tempDirectoryField = TextFieldWithBrowseButton()
-
+    
     private var modified = false
-
+    
     init {
         // Setup file chooser for OpenSCAD path
         val descriptor = FileChooserDescriptor(true, false, false, false, false, false)
@@ -61,12 +61,12 @@ class OpenSCADSettingsConfigurable(private val project: Project) : Configurable 
                 openscadPathField.text = file.path
             }
         }
-
+        
         // Setup library paths text area
         libraryPathsField.rows = 5
         libraryPathsField.lineWrap = false
         libraryPathsScrollPane.preferredSize = java.awt.Dimension(400, 100)
-
+        
         // Setup file chooser for temp directory
         val tempDirDescriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
             .withTitle("Select Temp Directory")
@@ -77,24 +77,24 @@ class OpenSCADSettingsConfigurable(private val project: Project) : Configurable 
                 tempDirectoryField.text = file.path
             }
         }
-
+        
         openscadPathField.textField.document.addDocumentListener(object : javax.swing.event.DocumentListener {
             override fun insertUpdate(e: javax.swing.event.DocumentEvent?) { modified = true }
             override fun removeUpdate(e: javax.swing.event.DocumentEvent?) { modified = true }
             override fun changedUpdate(e: javax.swing.event.DocumentEvent?) { modified = true }
         })
-
+        
         autoRenderCheckbox.addActionListener { modified = true }
         timeoutField.document.addDocumentListener(object : javax.swing.event.DocumentListener {
             override fun insertUpdate(e: javax.swing.event.DocumentEvent?) { modified = true }
             override fun removeUpdate(e: javax.swing.event.DocumentEvent?) { modified = true }
             override fun changedUpdate(e: javax.swing.event.DocumentEvent?) { modified = true }
         })
-
+        
         // Detect OpenSCAD installation
         detectOpenSCAD()
     }
-
+    
     private fun detectOpenSCAD() {
         val renderer = OpenSCADRenderer(project)
         val detectedPath = renderer.findOpenSCADExecutable()
@@ -104,9 +104,9 @@ class OpenSCADSettingsConfigurable(private val project: Project) : Configurable 
             detectedPathLabel.text = "⚠ OpenSCAD not found automatically"
         }
     }
-
+    
     override fun getDisplayName(): String = "OpenSCAD"
-
+    
     override fun createComponent(): JComponent {
         val panel = FormBuilder.createFormBuilder()
             .addLabeledComponent(JBLabel("OpenSCAD executable path:"), openscadPathField, 1, false)
@@ -141,13 +141,13 @@ class OpenSCADSettingsConfigurable(private val project: Project) : Configurable 
             .addTooltip("Custom directory for temporary render files. Leave empty to use system default (Linux uses ~/.cache for Flatpak compatibility)")
             .addComponentFillVertically(JPanel(), 0)
             .panel
-
+        
         val wrapper = JPanel(BorderLayout())
         wrapper.add(panel, BorderLayout.NORTH)
-
+        
         return wrapper
     }
-
+    
     override fun isModified(): Boolean {
         val settings = OpenSCADSettings.getInstance(project)
         val currentLibPaths = libraryPathsField.text.lines().filter { it.isNotBlank() }
@@ -164,11 +164,11 @@ class OpenSCADSettingsConfigurable(private val project: Project) : Configurable 
                 currentLibPaths != settings.libraryPaths ||
                 tempDirectoryField.text != settings.customTempDirectory
     }
-
+    
     override fun apply() {
         val settings = OpenSCADSettings.getInstance(project)
         val oldLibraryPaths = settings.libraryPaths.toList()
-
+        
         settings.openscadPath = openscadPathField.text
         settings.autoRenderOnSave = autoRenderCheckbox.isSelected
         settings.renderTimeout = timeoutField.text.toIntOrNull() ?: 30
@@ -184,15 +184,15 @@ class OpenSCADSettingsConfigurable(private val project: Project) : Configurable 
             .map { it.trim() }
             .toMutableList()
         settings.customTempDirectory = tempDirectoryField.text.trim()
-
+        
         // Re-index libraries if paths changed
         if (oldLibraryPaths != settings.libraryPaths) {
             OpenSCADLibraryIndexer.getInstance(project).reindex()
         }
-
+        
         modified = false
     }
-
+    
     override fun reset() {
         val settings = OpenSCADSettings.getInstance(project)
         openscadPathField.text = settings.openscadPath

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>org.openscad.plugin</id>
     <name>OpenSCAD</name>
-    <version>1.3.1</version>
+    <version>1.4.1</version>
     <vendor email="support@openscad.org" url="https://openscad.org">OpenSCAD Community</vendor>
 
     <description>


### PR DESCRIPTION
 Resolves the High Priority roadmap issue "3D Preview Colors and Grid" which was previously blocked by a caching/classloader problem. The fix was achieved by restructuring how rendering settings are applied at runtime rather than compile-time.                                                    
                  
  Changes:
  - Corrected material colors to match OpenSCAD's visual style
  - Fixed blown-out lighting in the JOGL viewer caused by non-normalized normals after model scaling (GL_NORMALIZE)
  - Enabled back-face culling and corrected material properties to eliminate visual artifacts
  - Added hardware-accelerated viewer toggle in Settings → Tools → OpenSCAD, with automatic fallback to the software renderer if OpenGL initialization fails
  - Preview mode menu now adapts to viewer capabilities (Wireframe and Debug modes only available with software renderer)

<img width="1824" height="978" alt="image" src="https://github.com/user-attachments/assets/193be8b9-3165-4110-910d-7bc42bb77d2e" />

Thanks for the great plugin `l2trace99`!